### PR TITLE
Revert "wrong typo made the actions not work."

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
 
       - name: Create google-services-json
-        run: echo '${{KEY}}' > app/google-services.json
+        uses: echo '${{KEY}}' > app/google-services.json
 
       - name: Gradle permission
         run: chmod +x gradlew


### PR DESCRIPTION
This reverts commit d16c380d8f5da6ce44139caa316ac291751dc455.